### PR TITLE
Implemented feeding optional arguments to scripts

### DIFF
--- a/example/config/config.yml
+++ b/example/config/config.yml
@@ -28,3 +28,4 @@ scripts:
     output_file: density_temperature.png
     section: Density-Temperature
     title: Density-Temperature
+    additional_args: regular, cividis

--- a/swift-pipeline
+++ b/swift-pipeline
@@ -297,6 +297,8 @@ if __name__ == "__main__":
                 args.output,
                 "-C",
                 config.config_directory,
+		"-a",
+		script.additional_args,
             ]
         )
 

--- a/swift-pipeline
+++ b/swift-pipeline
@@ -260,8 +260,8 @@ if __name__ == "__main__":
     # Now that we have auto_plotter_metadata we can use it to check if we have
     # inadvertently created multiple plots with the same filename.
     if args.debug:
-        figure_filenames = {plot.filename : 0 for plot in auto_plotter_metadata.plots}
-        
+        figure_filenames = {plot.filename: 0 for plot in auto_plotter_metadata.plots}
+
         for plot in auto_plotter_metadata.plots:
             figure_filenames[plot.filename] += 1
 
@@ -297,8 +297,8 @@ if __name__ == "__main__":
                 args.output,
                 "-C",
                 config.config_directory,
-		"-a",
-		script.additional_args,
+                "-a",
+                script.additional_args,
             ]
         )
 

--- a/swiftpipeline/argumentparser.py
+++ b/swiftpipeline/argumentparser.py
@@ -6,6 +6,7 @@ import argparse as ap
 from typing import List, Union, Tuple, Optional
 from swiftpipeline.config import Config
 
+
 class ScriptArgumentParser(object):
     """
     Script argument parser for ``swiftpipeline`` additional scripts.
@@ -146,11 +147,13 @@ class ScriptArgumentParser(object):
             if args.run_names is not None
             else [None] * self.number_of_inputs
         )
-        print (args.additional_args)
-        if args.additional_args == ['']:
+        print(args.additional_args)
+        if args.additional_args == [""]:
             self.additional_args = None
         else:
-            self.additional_args = [s.lstrip() for s in args.additional_args[0].split(',')]
+            self.additional_args = [
+                s.lstrip() for s in args.additional_args[0].split(",")
+            ]
         self.output_directory = args.output_directory
         self.config_directory = args.config
 

--- a/swiftpipeline/argumentparser.py
+++ b/swiftpipeline/argumentparser.py
@@ -147,7 +147,6 @@ class ScriptArgumentParser(object):
             if args.run_names is not None
             else [None] * self.number_of_inputs
         )
-        print(args.additional_args)
         if args.additional_args == [""]:
             self.additional_args = None
         else:

--- a/swiftpipeline/argumentparser.py
+++ b/swiftpipeline/argumentparser.py
@@ -6,7 +6,6 @@ import argparse as ap
 from typing import List, Union, Tuple, Optional
 from swiftpipeline.config import Config
 
-
 class ScriptArgumentParser(object):
     """
     Script argument parser for ``swiftpipeline`` additional scripts.
@@ -20,6 +19,7 @@ class ScriptArgumentParser(object):
     + ``-n``: List of run names, optional, for use in legends.
     + ``-o``: Output directory for the figure.
     + ``-C``: Configuration directory (contains the ``config``.yml)
+    + ``-a``: Additional args for a given script
     """
 
     parser: ap.ArgumentParser
@@ -43,6 +43,9 @@ class ScriptArgumentParser(object):
 
     # Config object containing all relevant information.
     config: Config
+
+    # additional arguments for a given script
+    additional_args: str
 
     def __init__(self, description):
         """
@@ -115,6 +118,15 @@ class ScriptArgumentParser(object):
             required=True,
         )
 
+        self.parser.add_argument(
+            "-a",
+            "--additional-args",
+            help="Additional command line args for a given script",
+            type=str,
+            required=False,
+            nargs="*",
+        )
+
         return
 
     def __parse_arguments(self):
@@ -134,6 +146,11 @@ class ScriptArgumentParser(object):
             if args.run_names is not None
             else [None] * self.number_of_inputs
         )
+        print (args.additional_args)
+        if args.additional_args == ['']:
+            self.additional_args = None
+        else:
+            self.additional_args = [s.lstrip() for s in args.additional_args[0].split(',')]
         self.output_directory = args.output_directory
         self.config_directory = args.config
 

--- a/swiftpipeline/config.py
+++ b/swiftpipeline/config.py
@@ -132,4 +132,3 @@ class Config(object):
         self.scripts = [Script(script_dict=script_dict) for script_dict in raw_scripts]
 
         return
-

--- a/swiftpipeline/config.py
+++ b/swiftpipeline/config.py
@@ -5,7 +5,6 @@ Configuration object for the entire pipeline.
 import yaml
 from typing import List
 
-
 # Items to read directly from the yaml file with their defaults
 direct_read = {
     "auto_plotter_directory": None,
@@ -37,6 +36,8 @@ class Script(object):
     # Show on webpage; Defaults to True but used to disable webpage plotting
     # in the config file if required.
     show_on_webpage: bool
+    # additional arguments to be fed to a given script
+    additional_args: str
 
     def __init__(self, script_dict: dict):
         """
@@ -49,7 +50,7 @@ class Script(object):
         self.section = script_dict.get("section", "")
         self.title = script_dict.get("title", "")
         self.show_on_webpage = script_dict.get("show_on_webpage", True)
-
+        self.additional_args = script_dict.get("additional_args", "")
         return
 
     def __str__(self):

--- a/tests/test_config/config.yml
+++ b/tests/test_config/config.yml
@@ -22,3 +22,4 @@ scripts:
     output_file: density_temperature.png
     section: Density-Temperature
     title: Density-Temperature Diagram
+    additional_args: regular, cividis


### PR DESCRIPTION
Can use `additional_args` field to feed comma separated list of args to each script in the `config.yml`. This is parsed as a list of strings. Useful to e.g. produce multiple plots with a single script (e.g. plotting different element abundances or hydrogen species) or tweaking plots. 