### PR TITLE
Fix the bug in comparing runs with the same names at different z

### DIFF
--- a/swift-pipeline
+++ b/swift-pipeline
@@ -178,9 +178,11 @@ if __name__ == "__main__":
     else:
         # First, check if the snapshots are all at the same redshift
         redshifts = {data.metadata.redshift for data in snapshots}
-        if len(redshifts) == len(snapshots):
-            # All different redshifts!
+        # If the size of the set is one, then all redshifts are the same
+        if len(redshifts) == 1:
+            # All redshifts are the same! No need to modify runs' names
             run_names = [data.metadata.run_name for data in snapshots]
+        # If the size of the set > 1, then at least two runs have different redshifts
         else:
             # Need to append appropriate redshifts to names.
             run_names = [


### PR DESCRIPTION
Hi @JBorrow,

I found a bug that does not allow comparing snapshots from the same run at different redshifts. I added comments to the lines of the code I modified so that it is clear why such comparisons would not work before and are possible now.

Just to illustrate, with my change I get the expected results, e.g.

![stellar_mass_halo_mass_M200_centrals_100](https://user-images.githubusercontent.com/20153933/101178641-88c42300-3649-11eb-900c-5829a9e6a62f.png)
