### PR TITLE
Support for multiple configuration files, auto plotter configs and registration files

### DIFF
--- a/example/run.sh
+++ b/example/run.sh
@@ -2,8 +2,12 @@
 
 # Grab test data
 
-wget http://virgodb.cosma.dur.ac.uk/swift-webstorage/IOExamples/cosmo_volume_example.hdf5 -O cosmo_0000.hdf5
-wget http://virgodb.cosma.dur.ac.uk/swift-webstorage/IOExamples/cosmo_volume_example.properties -O cosmo_0000.properties
+if [ ! -f cosmo_0000.hdf5 ]; then
+  wget http://virgodb.cosma.dur.ac.uk/swift-webstorage/IOExamples/cosmo_volume_example.hdf5 -O cosmo_0000.hdf5
+fi
+if [ ! -f cosmo_0000.properties ]; then
+  wget http://virgodb.cosma.dur.ac.uk/swift-webstorage/IOExamples/cosmo_volume_example.properties -O cosmo_0000.properties
+fi
 
 # Example of how to run the new pipeline.
 
@@ -27,8 +31,8 @@ swift-pipeline -C example/config \
                -c cosmo_0000.properties \
                -s cosmo_0000.hdf5 \
                -o test_output \
-               -i . 
-               
+               -i .
+
 return_code=$(( $return_code > $? ? $return_code : $? ))
 
 # With custom names

--- a/format.sh
+++ b/format.sh
@@ -21,6 +21,7 @@ black="./black_formatting_env/bin/python3 -m black"
 
 # Formatting command
 files=$(find swiftpipeline/ -name "*.py")
+files="$files $(find tests/ -name '*.py')"
 files="$files swift-image swift-pipeline"
 cmd="$black -t py38 $files"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ swiftsimio>=6.0.0
 unyt
 tqdm
 p_tqdm
-velociraptor>=0.15.7
+velociraptor>=0.15.8

--- a/swift-pipeline
+++ b/swift-pipeline
@@ -308,11 +308,10 @@ if __name__ == "__main__":
         halo_catalogue_filename = f"{args.input[0]}/{args.catalogues[0]}"
         print_if_debug(f"Loading halo catalogue at {halo_catalogue_filename}.")
 
-        registration_filename = (
-            None
-            if config.auto_plotter_registration is None
-            else f"{config.config_directory}/{config.auto_plotter_registration}"
-        )
+        registration_filename = [
+            f"{config.config_directory}/{file_path}"
+            for file_path in config.auto_plotter_registration
+        ]
 
         if registration_filename is not None:
             print_if_debug(

--- a/swift-pipeline
+++ b/swift-pipeline
@@ -258,11 +258,7 @@ if __name__ == "__main__":
         style.use(stylesheet_path)
 
     # Reverse so most recently modified is at the top.
-    auto_plotter_configs = list(
-        reversed(
-            glob(f"{config.config_directory}/{config.auto_plotter_directory}/*.yml")
-        )
-    )
+    auto_plotter_configs = list(config.auto_plotter_configs)
 
     box_size_correction_directory = f"{config.config_directory}/box_size_corrections"
 
@@ -300,7 +296,7 @@ if __name__ == "__main__":
         # Run the pipeline based on the arguments if only a single simulation is
         # included and generate the metadata yaml file.
         print_if_debug(
-            f"Generating initial AutoPlotter instance for {config.auto_plotter_directory}."
+            f"Generating initial AutoPlotter instance for {auto_plotter_configs}."
         )
 
         auto_plotter = AutoPlotter(

--- a/swiftpipeline/config.py
+++ b/swiftpipeline/config.py
@@ -9,7 +9,7 @@ import glob
 
 # Items to read directly from the yaml file with their defaults
 direct_read = {
-    "auto_plotter_registration": None,
+    "auto_plotter_registration": [],
     "auto_plotter_global_mask": None,
     "observational_data_directory": None,
     "matplotlib_stylesheet": "default",
@@ -121,6 +121,7 @@ class Config(object):
         "config_directory",
         "raw_config",
         "auto_plotter_configs",
+        "auto_plotter_registrations",
     ]
 
     def __init__(self, config_directory: str):
@@ -158,6 +159,14 @@ class Config(object):
         with open(f"{self.config_directory}/config.yml", "r") as handle:
             self.raw_config = yaml.safe_load(handle)
 
+        if "auto_plotter_registration" in self.raw_config:
+            if not isinstance(self.raw_config["auto_plotter_registration"], list):
+                self.raw_config["auto_plotter_registration"] = [
+                    self.raw_config["auto_plotter_registration"]
+                ]
+        else:
+            self.raw_config["auto_plotter_registration"] = []
+
         if "extra_config" in self.raw_config:
             for extra_config_file in self.raw_config["extra_config"]:
                 with open(
@@ -165,11 +174,19 @@ class Config(object):
                 ) as handle:
                     extra_raw_config = yaml.safe_load(handle)
                 for key in extra_raw_config:
-                    if key in ["scripts", "special_modes", "auto_plotter_configs"]:
+                    if key in [
+                        "scripts",
+                        "special_modes",
+                        "auto_plotter_configs",
+                        "auto_plotter_registration",
+                    ]:
                         # append additional items
                         if not key in self.raw_config:
                             self.raw_config[key] = []
-                        for extra_item in extra_raw_config[key]:
+                        extra_list = extra_raw_config[key]
+                        if not isinstance(extra_list, list):
+                            extra_list = [extra_list]
+                        for extra_item in extra_list:
                             self.raw_config[key].append(extra_item)
                     else:
                         # overwrite the original value

--- a/swiftpipeline/config.py
+++ b/swiftpipeline/config.py
@@ -156,6 +156,23 @@ class Config(object):
         with open(f"{self.config_directory}/config.yml", "r") as handle:
             self.raw_config = yaml.safe_load(handle)
 
+        if "extra_config" in self.raw_config:
+            for extra_config_file in self.raw_config["extra_config"]:
+                with open(
+                    f"{self.config_directory}/{extra_config_file}", "r"
+                ) as handle:
+                    extra_raw_config = yaml.safe_load(handle)
+                for key in extra_raw_config:
+                    if key in ["scripts", "special_modes"]:
+                        # append additional items
+                        if not key in self.raw_config:
+                            self.raw_config[key] = []
+                        for extra_item in extra_raw_config[key]:
+                            self.raw_config[key].append(extra_item)
+                    else:
+                        # overwrite the original value
+                        self.raw_config[key] = extra_raw_config[key]
+
         return
 
     def __extract_to_variables(self):

--- a/swiftpipeline/config.py
+++ b/swiftpipeline/config.py
@@ -168,16 +168,11 @@ class Config(object):
         with open(f"{self.config_directory}/config.yml", "r") as handle:
             self.raw_config = yaml.safe_load(handle)
         for key in appendable_config_keys:
-            if key not in self.raw_config:
+            if key in self.raw_config:
+                if not isinstance(self.raw_config[key], list):
+                    self.raw_config[key] = [self.raw_config[key]]
+            else:
                 self.raw_config[key] = []
-
-        if "auto_plotter_registration" in self.raw_config:
-            if not isinstance(self.raw_config["auto_plotter_registration"], list):
-                self.raw_config["auto_plotter_registration"] = [
-                    self.raw_config["auto_plotter_registration"]
-                ]
-        else:
-            self.raw_config["auto_plotter_registration"] = []
 
         if "extra_config" in self.raw_config:
             for extra_config_file in self.raw_config["extra_config"]:

--- a/tests/test_config/config.yml
+++ b/tests/test_config/config.yml
@@ -24,3 +24,6 @@ scripts:
     title: Density-Temperature Diagram
     additional_args:
       quantity_type: hydro
+
+extra_config:
+ - extra_config.yml

--- a/tests/test_config/extra_config.yml
+++ b/tests/test_config/extra_config.yml
@@ -6,3 +6,7 @@ scripts:
     title: Pressure-Temperature Diagram
     additional_args:
       quantity_type: hydro
+
+auto_plotter_configs:
+  - extra_auto_plotter_folder
+  - extra_auto_plotter_file.yml

--- a/tests/test_config/extra_config.yml
+++ b/tests/test_config/extra_config.yml
@@ -1,0 +1,8 @@
+scripts:
+  - filename: scripts/pressure_temperature.py
+    caption: Hello World
+    output_file: pressure_temperature.png
+    section: Pressure-Temperature
+    title: Pressure-Temperature Diagram
+    additional_args:
+      quantity_type: hydro

--- a/tests/test_config/extra_config.yml
+++ b/tests/test_config/extra_config.yml
@@ -10,3 +10,5 @@ scripts:
 auto_plotter_configs:
   - extra_auto_plotter_folder
   - extra_auto_plotter_file.yml
+
+auto_plotter_registration: extra_registration.py

--- a/tests/test_example_config.py
+++ b/tests/test_example_config.py
@@ -14,7 +14,6 @@ def test_config(path="tests/test_config"):
 
     config = Config(config_directory=path)
 
-
 def test_image_config(path="tests/test_config"):
     """
     Tests loading an image config doesn't induce a crash,

--- a/tests/test_example_config.py
+++ b/tests/test_example_config.py
@@ -14,6 +14,7 @@ def test_config(path="tests/test_config"):
 
     config = Config(config_directory=path)
 
+
 def test_image_config(path="tests/test_config"):
     """
     Tests loading an image config doesn't induce a crash,


### PR DESCRIPTION
Requires https://github.com/SWIFTSIM/velociraptor-python/pull/92.

With this PR, it is possible to load additional configuration parameters from a different configuration file into a `config.yml`, like this:
```
<normal configuration>
...
extra_config:
 - extra_configuration_file.yml
```
Additional scripts and special modes found in this additional configuration file (or additional files) are appended to the existing lists. Other configuration parameters that are found in additional files are overwritten.

With this PR, it is now also possible to specify a list of registration functions:
```
auto_plotter_registration:
 - registration_function1.py
 - registration_function2.py
...
```
Single element `auto_plotter_registration` parameters in existing configuration files are automatically converted into a list. Additional registration functions found in extra configuration files are appended to the list.

Finally, `auto_plotter_directory` has been replaced by `auto_plotter_configs`, i.e. a list of individual configuration files and/or directories for which all `*.yml` files are included:
```
auto_plotter_configs:
 - single_auto_plotter_configuration_file.yml
 - folder_containing_auto_plotter_configuration_files
```
To support legacy configuration files, the list is initialised with all `*.yml` files in the `auto_plotter_directory`, if that configuration parameter is still provided.

All paths are always relative to the configuration directory. So in the hypothetical case where we create a new COLIBRE pipeline in `pipeline-configs/colibre-jets`, we could use the following `config.yml`:
```
extra_config:
 - ../colibre/config.yml

scripts:
 - <additional scripts for colibre-jets>
 ...

auto_plotter_configs:
 - <additional auto plotter config files for colibre-jets>
 ...

auto_plotter_registration:
 - <additional auto plotter registration files for colibre-jets>
 ...
```